### PR TITLE
Wrong Channels used in Assert

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -30,7 +30,7 @@ namespace Mirror.FizzySteam
 
         protected Common(FizzySteamyMirror transport)
         {
-            Debug.Assert(channels.Length < 100, "FizzySteamyMirror does not support more than 99 channels.");
+            Debug.Assert(transport.Channels.Length < 100, "FizzySteamyMirror does not support more than 99 channels.");
             this.channels = transport.Channels;
 
             callback_OnNewConnection = Callback<P2PSessionRequest_t>.Create(OnNewConnection);


### PR DESCRIPTION
Throws a null ref since `channels` isn't assigned yet.